### PR TITLE
deprecated Stream handling in Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,13 @@ lazy val pirate =
     , scalacOptions in (Compile, console) := Seq("-language:_", "-feature")
     , scalacOptions in (Test, console) := Seq("-language:_", "-feature")
     , scalacOptions in Test := Seq("-Yrangepos")
+    , unmanagedSourceDirectories in Test ++= {
+        val sharedSourceDir = baseDirectory.value / "src/test"
+        if (scalaVersion.value.startsWith("2.13"))
+          Seq(sharedSourceDir / "scala-2.13")
+        else
+          Seq(sharedSourceDir / "scala-2.13-")
+      }
     , testFrameworks := Seq(TestFramework("hedgehog.sbt.Framework"))
     , resolvers += "bintray-scala-hedgehog" at "https://dl.bintray.com/hedgehogqa/scala-hedgehog"
     , libraryDependencies ++= Seq(

--- a/src/test/scala-2.13-/pirate/spec/LawsCompat.scala
+++ b/src/test/scala-2.13-/pirate/spec/LawsCompat.scala
@@ -1,0 +1,5 @@
+package pirate.spec
+
+trait LawsCompat {
+  type LazyCollection[+A] = Stream[A]
+}

--- a/src/test/scala-2.13/pirate/spec/LawsCompat.scala
+++ b/src/test/scala-2.13/pirate/spec/LawsCompat.scala
@@ -1,0 +1,8 @@
+package pirate.spec
+
+import scalaz.EphemeralStream
+
+trait LawsCompat {
+  // TODO: Replace EphemeralStream with LazyList once LazyList support is available in Scalaz.
+  type LazyCollection[A] = EphemeralStream[A]
+}

--- a/src/test/scala/pirate.spec/Laws.scala
+++ b/src/test/scala/pirate.spec/Laws.scala
@@ -8,7 +8,7 @@ import hedgehog.runner._
 
 /* ripped from scalaz-scalacheck-binding due to binary compatability issues */
 
-object Laws {
+object Laws extends LawsCompat {
   object equal {
     def commutativity[A](genA: Gen[A])(implicit A: Equal[A]): Property = for {
       a <- genA.log("a")
@@ -334,7 +334,7 @@ object Laws {
       List(
         property(s"$name - $lawName: identity traverse", identityTraverse[F, Int, Int](genFInt, genIntToInt))
       , property(s"$name - $lawName: purity.option", purity[F, Option, Int](genFInt))
-      , property(s"$name - $lawName: purity.stream", purity[F, Stream, Int](genFInt))
+      , property(s"$name - $lawName: purity.lazyCollection", purity[F, LazyCollection, Int](genFInt))
       , property(s"$name - $lawName: sequential fusion", sequentialFusion[F, Option, List, Int, Int, Int](genFInt, genIntToListInt, genIntToOptionInt))
       )
     }


### PR DESCRIPTION
Scala's `Stream` is `deprecated` and `LazyList` should be used in Scala 2.13 so a compatibility `trait` has been added for testing.
For now, [Scalaz doesn't support `LazyList`](https://github.com/scalaz/scalaz/issues/2081) so `scalaz.EphemeralStream` is used instead for Scala 2.13.